### PR TITLE
Add circleci automated build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # KlSS
+
+[![CircleCI](https://circleci.com/gh/lebodro/KlSS.svg?style=svg)](https://circleci.com/gh/lebodro/KlSS)
+
 Simple puzzle game made with MonoGame.
 
 ## Build and Run

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env sh
 
+set -x
+set -e
+
 export PROJECT_NAME=KlSS
 export BUILD_CONFIGURATION='release'
 
@@ -27,5 +30,5 @@ dotnet build --configuration ${BUILD_CONFIGURATION}
 dotnet publish -r ${BUILD_PLATFORM} --configuration ${BUILD_CONFIGURATION} /p:TrimUnusedDependencies=true
 
 # artifacts
-mkdir ${ARTIFACTS_DIR}/
+mkdir -p ${ARTIFACTS_DIR}
 cd ${PUBLISH_DIR} && zip -r ${ARTIFACT_FULL_PATH} ./

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+
+export PROJECT_NAME=KlSS
+export BUILD_CONFIGURATION='release'
+
+export ARTIFACT_FILENAME=${PROJECT_NAME}-${BUILD_PLATFORM}.zip
+export ARTIFACTS_DIR=~/repo/artifacts
+export ARTIFACT_FULL_PATH=${ARTIFACTS_DIR}/${OUTPUT_FILE}
+
+export PUBLISH_DIR=~/repo/bin/release/netcoreapp2.2/${BUILD_PLATFORM}/publish
+export MGCB_VERSION=3.7.0.4
+export MGCB_PACKAGE_PATH=/root/.nuget/packages/monogame.content.builder/${MGCB_VERSION}/build/MGCB/build
+
+# adding zip cli for artifact zipping, todo: add this to base image
+apt-get update && apt-get install -y zip
+
+dotnet restore
+
+# workaround to ensure monogame.content.builder package binaries are executable
+# TODO: check if there's a command only to download nuget from csproj only instead
+dotnet build --configuration ${BUILD_CONFIGURATION} || true
+chmod +x ${MGCB_PACKAGE_PATH}/ffprobe
+chmod +x ${MGCB_PACKAGE_PATH}/ffmpeg
+
+# actual build
+dotnet build --configuration ${BUILD_CONFIGURATION}
+dotnet publish -r ${BUILD_PLATFORM} --configuration ${BUILD_CONFIGURATION} /p:TrimUnusedDependencies=true
+
+# artifacts
+mkdir ${ARTIFACTS_DIR}/
+cd ${PUBLISH_DIR} && zip -r ${ARTIFACT_FULL_PATH} ./

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -7,10 +7,10 @@ export PROJECT_NAME=KlSS
 export BUILD_CONFIGURATION='release'
 
 export ARTIFACT_FILENAME=${PROJECT_NAME}-${BUILD_PLATFORM}.zip
-export ARTIFACTS_DIR=~/repo/artifacts
+export ARTIFACTS_DIR=/root/repo/artifacts
 export ARTIFACT_FULL_PATH=${ARTIFACTS_DIR}/${OUTPUT_FILE}
 
-export PUBLISH_DIR=~/repo/bin/release/netcoreapp2.2/${BUILD_PLATFORM}/publish
+export PUBLISH_DIR=/root/repo/bin/release/netcoreapp2.2/${BUILD_PLATFORM}/publish
 export MGCB_VERSION=3.7.0.4
 export MGCB_PACKAGE_PATH=/root/.nuget/packages/monogame.content.builder/${MGCB_VERSION}/build/MGCB/build
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -x
 set -e
@@ -8,7 +8,7 @@ export BUILD_CONFIGURATION='release'
 
 export ARTIFACT_FILENAME=${PROJECT_NAME}-${BUILD_PLATFORM}.zip
 export ARTIFACTS_DIR=/root/repo/artifacts
-export ARTIFACT_FULL_PATH=${ARTIFACTS_DIR}/${OUTPUT_FILE}
+export ARTIFACT_FULL_PATH=${ARTIFACTS_DIR}/${ARTIFACT_FILENAME}
 
 export PUBLISH_DIR=/root/repo/bin/release/netcoreapp2.2/${BUILD_PLATFORM}/publish
 export MGCB_VERSION=3.7.0.4

--- a/circle.yml
+++ b/circle.yml
@@ -2,14 +2,17 @@ version: 2
 
 .job_configuration: &job_configuration
   docker:
-    - image: gmantaos/monogame
+    - image: gableroux/dotnet-mono-monogame-tmp # this is until docker hub publishes the real images
   working_directory: ~/repo
   steps:
     - checkout
+    - run: dotnet restore
+    - run: chmod +x /root/.nuget/packages/monogame.content.builder/3.7.0.4/build/MGCB/build/ffprobe
+    - run: chmod +x /root/.nuget/packages/monogame.content.builder/3.7.0.4/build/MGCB/build/ffmpeg
     - run: dotnet build KlSS.csproj --configuration $BUILDCONFIGURATION
     - run: dotnet publish -r $BUILDPLATFORM --configuration $BUILDCONFIGURATION /p:TrimUnusedDependencies=true
     - store_artifacts:
-        path: ~/repo/
+        path: ~/repo/bin/release/netcoreapp2.2/$BUILDPLATFORM/publish
 
 jobs:
   windows:
@@ -27,11 +30,6 @@ jobs:
     environment:
       BUILDCONFIGURATION: 'release'
       BUILDPLATFORM: 'osx-x64'
-#  deploy:
-#    docker:
-#      - image: dosowisko/butler
-#    steps:
-#      - run: butler --help
 
 workflows:
   version: 2
@@ -40,4 +38,3 @@ workflows:
       - windows
       - linux
       - macos
-#      - deploy

--- a/circle.yml
+++ b/circle.yml
@@ -15,9 +15,10 @@ version: 2
     - run: dotnet build KlSS.csproj --configuration $BUILDCONFIGURATION
     - run: dotnet publish -r $BUILDPLATFORM --configuration $BUILDCONFIGURATION /p:TrimUnusedDependencies=true
     - run: apt-get update && apt-get install -y zip
-    - run: cd ~/repo/bin/release/netcoreapp2.2/$BUILDPLATFORM/publish && zip -r ~/repo/KlSS.zip ./
+    - run: mkdir ~/repo/artifacts/
+    - run: cd ~/repo/bin/release/netcoreapp2.2/$BUILDPLATFORM/publish && zip -r ~/repo/artifacts/KlSS-$BUILDPLATFORM.zip ./
     - store_artifacts:
-        path: ~/repo/KlSS.zip
+        path: ~/repo/artifacts/
 
 jobs:
   windows:

--- a/circle.yml
+++ b/circle.yml
@@ -8,33 +8,35 @@ version: 2
     - checkout
     - run: dotnet restore
     # workaround to ensure monogame.content.builder package
-    - run: dotnet build KlSS.csproj --configuration $BUILDCONFIGURATION || true
-    - run: chmod +x /root/.nuget/packages/monogame.content.builder/3.7.0.4/build/MGCB/build/ffprobe
-    - run: chmod +x /root/.nuget/packages/monogame.content.builder/3.7.0.4/build/MGCB/build/ffmpeg
+    - run: dotnet build $PROJECT_NAME.csproj --configuration $BUILDCONFIGURATION || true
+    - run: chmod +x /root/.nuget/packages/monogame.content.builder/$MONOGAME_CONTENT_VERSION/build/MGCB/build/ffprobe
+    - run: chmod +x /root/.nuget/packages/monogame.content.builder/$MONOGAME_CONTENT_VERSION/build/MGCB/build/ffmpeg
     # actual build
-    - run: dotnet build KlSS.csproj --configuration $BUILDCONFIGURATION
+    - run: dotnet build $PROJECT_NAME.csproj --configuration $BUILDCONFIGURATION
     - run: dotnet publish -r $BUILDPLATFORM --configuration $BUILDCONFIGURATION /p:TrimUnusedDependencies=true
     - run: apt-get update && apt-get install -y zip
     - run: mkdir ~/repo/artifacts/
-    - run: cd ~/repo/bin/release/netcoreapp2.2/$BUILDPLATFORM/publish && zip -r ~/repo/artifacts/KlSS-$BUILDPLATFORM.zip ./
+    - run: cd ~/repo/bin/release/netcoreapp2.2/$BUILDPLATFORM/publish && zip -r ~/repo/artifacts/$PROJECT_NAME-$BUILDPLATFORM.zip ./
     - store_artifacts:
         path: ~/repo/artifacts/
+
+environment:
+  BUILDCONFIGURATION: 'release'
+  PROJECT_NAME: KlSS
+  MONOGAME_CONTENT_VERSION: 3.7.0.4
 
 jobs:
   windows:
     <<: *job_configuration
     environment:
-      BUILDCONFIGURATION: 'release'
       BUILDPLATFORM: 'win-x64'
   linux:
     <<: *job_configuration
     environment:
-      BUILDCONFIGURATION: 'release'
       BUILDPLATFORM: 'linux-x64'
   macos:
     <<: *job_configuration
     environment:
-      BUILDCONFIGURATION: 'release'
       BUILDPLATFORM: 'osx-x64'
 
 workflows:
@@ -44,3 +46,4 @@ workflows:
       - windows
       - linux
       - macos
+

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ version: 2
 
 .job_configuration: &job_configuration
   docker:
-    - image: gableroux/dotnet-mono-monogame-tmp # this is until docker hub publishes the real images
+    - image: gableroux/dotnet-mono-monogame:latest
   working_directory: ~/repo
   steps:
     - checkout

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,7 @@ version: 2
     # actual build
     - run: dotnet build KlSS.csproj --configuration $BUILDCONFIGURATION
     - run: dotnet publish -r $BUILDPLATFORM --configuration $BUILDCONFIGURATION /p:TrimUnusedDependencies=true
+    - run: apt-get update && apt-get install -y zip
     - run: zip -r ~/repo/KlSS.zip ~/repo/bin/release/netcoreapp2.2/$BUILDPLATFORM/publish
     - store_artifacts:
         path: ~/repo/KlSS.zip

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,24 @@
+.job_configuration: &job_configuration
+  pool:
+    vmImage: 'ubuntu-16.04'
+    steps:
+      - script: dotnet build KlSS.csproj --configuration $(buildConfiguration)
+      - script: dotnet publish -r $(buildPlatform) --configuration $(buildConfiguration) /p:TrimUnusedDependencies=true
+      - store_artifacts:
+          path: ./
+jobs:
+  - job: windows
+    <<: *job_configuration
+    variables:
+      buildConfiguration: 'release'
+      buildPlatform: 'win-x64'
+  - job: linux
+    <<: *job_configuration
+    variables:
+      buildConfiguration: 'release'
+      buildPlatform: 'linux-x64'
+  - job: macos
+    <<: *job_configuration
+    variables:
+      buildConfiguration: 'release'
+      buildPlatform: 'osx-x64'

--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,8 @@ version: 2
   working_directory: ~/repo
   steps:
     - checkout
-    - run: dotnet build KlSS.csproj --configuration $(buildConfiguration)
-    - run: dotnet publish -r $(buildPlatform) --configuration $(buildConfiguration) /p:TrimUnusedDependencies=true
+    - run: dotnet build KlSS.csproj --configuration $buildConfiguration
+    - run: dotnet publish -r $buildPlatform --configuration $buildConfiguration /p:TrimUnusedDependencies=true
     - store_artifacts:
         path: ~/repo/
 

--- a/circle.yml
+++ b/circle.yml
@@ -6,38 +6,22 @@ version: 2
   working_directory: ~/repo
   steps:
     - checkout
-    - run: dotnet restore
-    # workaround to ensure monogame.content.builder package
-    - run: dotnet build $PROJECT_NAME.csproj --configuration $BUILDCONFIGURATION || true
-    - run: chmod +x /root/.nuget/packages/monogame.content.builder/$MONOGAME_CONTENT_VERSION/build/MGCB/build/ffprobe
-    - run: chmod +x /root/.nuget/packages/monogame.content.builder/$MONOGAME_CONTENT_VERSION/build/MGCB/build/ffmpeg
-    # actual build
-    - run: dotnet build $PROJECT_NAME.csproj --configuration $BUILDCONFIGURATION
-    - run: dotnet publish -r $BUILDPLATFORM --configuration $BUILDCONFIGURATION /p:TrimUnusedDependencies=true
-    - run: apt-get update && apt-get install -y zip
-    - run: mkdir ~/repo/artifacts/
-    - run: cd ~/repo/bin/release/netcoreapp2.2/$BUILDPLATFORM/publish && zip -r ~/repo/artifacts/$PROJECT_NAME-$BUILDPLATFORM.zip ./
+    - run: ci/build.sh
     - store_artifacts:
         path: ~/repo/artifacts/
-
-environment:
-  BUILDCONFIGURATION: 'release'
-  PROJECT_NAME: KlSS
-  MONOGAME_CONTENT_VERSION: 3.7.0.4
-
 jobs:
   windows:
     <<: *job_configuration
     environment:
-      BUILDPLATFORM: 'win-x64'
+      BUILD_PLATFORM: 'win-x64'
   linux:
     <<: *job_configuration
     environment:
-      BUILDPLATFORM: 'linux-x64'
+      BUILD_PLATFORM: 'linux-x64'
   macos:
     <<: *job_configuration
     environment:
-      BUILDPLATFORM: 'osx-x64'
+      BUILD_PLATFORM: 'osx-x64'
 
 workflows:
   version: 2
@@ -46,4 +30,3 @@ workflows:
       - windows
       - linux
       - macos
-

--- a/circle.yml
+++ b/circle.yml
@@ -14,9 +14,9 @@ version: 2
     # actual build
     - run: dotnet build KlSS.csproj --configuration $BUILDCONFIGURATION
     - run: dotnet publish -r $BUILDPLATFORM --configuration $BUILDCONFIGURATION /p:TrimUnusedDependencies=true
-    - run: mv ~/repo/bin/release/netcoreapp2.2/$BUILDPLATFORM/publish ~/repo/artifacts
+    - run: zip -r ~/repo/KlSS.zip ~/repo/bin/release/netcoreapp2.2/$BUILDPLATFORM/publish
     - store_artifacts:
-        path: ~/repo/artifacts
+        path: ~/repo/KlSS.zip
 
 jobs:
   windows:

--- a/circle.yml
+++ b/circle.yml
@@ -6,27 +6,27 @@ version: 2
   working_directory: ~/repo
   steps:
     - checkout
-    - run: dotnet build KlSS.csproj --configuration $buildConfiguration
-    - run: dotnet publish -r $buildPlatform --configuration $buildConfiguration /p:TrimUnusedDependencies=true
+    - run: dotnet build KlSS.csproj --configuration $BUILDCONFIGURATION
+    - run: dotnet publish -r $BUILDPLATFORM --configuration $BUILDCONFIGURATION /p:TrimUnusedDependencies=true
     - store_artifacts:
         path: ~/repo/
 
 jobs:
   windows:
     <<: *job_configuration
-    variables:
-      buildConfiguration: 'release'
-      buildPlatform: 'win-x64'
+    environment:
+      BUILDCONFIGURATION: 'release'
+      BUILDPLATFORM: 'win-x64'
   linux:
     <<: *job_configuration
-    variables:
-      buildConfiguration: 'release'
-      buildPlatform: 'linux-x64'
+    environment:
+      BUILDCONFIGURATION: 'release'
+      BUILDPLATFORM: 'linux-x64'
   macos:
     <<: *job_configuration
-    variables:
-      buildConfiguration: 'release'
-      buildPlatform: 'osx-x64'
+    environment:
+      BUILDCONFIGURATION: 'release'
+      BUILDPLATFORM: 'osx-x64'
 #  deploy:
 #    docker:
 #      - image: dosowisko/butler

--- a/circle.yml
+++ b/circle.yml
@@ -1,28 +1,43 @@
 version: 2
 
 .job_configuration: &job_configuration
-  pool:
-    vmImage: 'ubuntu-16.04'
-    steps:
-      - script: dotnet build KlSS.csproj --configuration $(buildConfiguration)
-      - script: dotnet publish -r $(buildPlatform) --configuration $(buildConfiguration) /p:TrimUnusedDependencies=true
-      - store_artifacts:
-          path: ./
+  docker:
+    - image: circleci/node:7.10
+  working_directory: ~/repo
+  steps:
+    - checkout
+    - script: dotnet build KlSS.csproj --configuration $(buildConfiguration)
+    - script: dotnet publish -r $(buildPlatform) --configuration $(buildConfiguration) /p:TrimUnusedDependencies=true
+    - store_artifacts:
+        path: ~/repo/
 
 jobs:
-  build:
-    windows:
-      <<: *job_configuration
-      variables:
-        buildConfiguration: 'release'
-        buildPlatform: 'win-x64'
-    linux:
-      <<: *job_configuration
-      variables:
-        buildConfiguration: 'release'
-        buildPlatform: 'linux-x64'
-    macos:
-      <<: *job_configuration
-      variables:
-        buildConfiguration: 'release'
-        buildPlatform: 'osx-x64'
+  windows:
+    <<: *job_configuration
+    variables:
+      buildConfiguration: 'release'
+      buildPlatform: 'win-x64'
+  linux:
+    <<: *job_configuration
+    variables:
+      buildConfiguration: 'release'
+      buildPlatform: 'linux-x64'
+  macos:
+    <<: *job_configuration
+    variables:
+      buildConfiguration: 'release'
+      buildPlatform: 'osx-x64'
+#  deploy:
+#    docker:
+#      - image: dosowisko/butler
+#    steps:
+#      - butler --help
+
+workflows:
+  version: 2
+  workflow:
+    jobs:
+      - windows
+      - linux
+      - macos
+#      - deploy

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ version: 2
 
 .job_configuration: &job_configuration
   docker:
-    - image: circleci/node:7.10
+    - image: gmantaos/monogame
   working_directory: ~/repo
   steps:
     - checkout

--- a/circle.yml
+++ b/circle.yml
@@ -14,8 +14,9 @@ version: 2
     # actual build
     - run: dotnet build KlSS.csproj --configuration $BUILDCONFIGURATION
     - run: dotnet publish -r $BUILDPLATFORM --configuration $BUILDCONFIGURATION /p:TrimUnusedDependencies=true
+    - run: mv ~/repo/bin/release/netcoreapp2.2/$BUILDPLATFORM/publish ~/repo/artifacts
     - store_artifacts:
-        path: ~/repo/bin/release/netcoreapp2.2/$BUILDPLATFORM/publish
+        path: ~/repo/artifacts
 
 jobs:
   windows:

--- a/circle.yml
+++ b/circle.yml
@@ -7,8 +7,6 @@ version: 2
   steps:
     - checkout
     - run: dotnet restore
-    - run: chmod +x /root/.nuget/packages/monogame.content.builder/3.7.0.4/build/MGCB/build/ffprobe
-    - run: chmod +x /root/.nuget/packages/monogame.content.builder/3.7.0.4/build/MGCB/build/ffmpeg
     - run: dotnet build KlSS.csproj --configuration $BUILDCONFIGURATION
     - run: dotnet publish -r $BUILDPLATFORM --configuration $BUILDCONFIGURATION /p:TrimUnusedDependencies=true
     - store_artifacts:

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,5 @@
+version: 2
+
 .job_configuration: &job_configuration
   pool:
     vmImage: 'ubuntu-16.04'
@@ -6,6 +8,7 @@
       - script: dotnet publish -r $(buildPlatform) --configuration $(buildConfiguration) /p:TrimUnusedDependencies=true
       - store_artifacts:
           path: ./
+
 jobs:
   - job: windows
     <<: *job_configuration

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,11 @@ version: 2
   steps:
     - checkout
     - run: dotnet restore
+    # workaround to ensure monogame.content.builder package
+    - run: dotnet build KlSS.csproj --configuration $BUILDCONFIGURATION || true
+    - run: chmod +x /root/.nuget/packages/monogame.content.builder/3.7.0.4/build/MGCB/build/ffprobe
+    - run: chmod +x /root/.nuget/packages/monogame.content.builder/3.7.0.4/build/MGCB/build/ffmpeg
+    # actual build
     - run: dotnet build KlSS.csproj --configuration $BUILDCONFIGURATION
     - run: dotnet publish -r $BUILDPLATFORM --configuration $BUILDCONFIGURATION /p:TrimUnusedDependencies=true
     - store_artifacts:

--- a/circle.yml
+++ b/circle.yml
@@ -10,18 +10,19 @@ version: 2
           path: ./
 
 jobs:
-  - job: windows
-    <<: *job_configuration
-    variables:
-      buildConfiguration: 'release'
-      buildPlatform: 'win-x64'
-  - job: linux
-    <<: *job_configuration
-    variables:
-      buildConfiguration: 'release'
-      buildPlatform: 'linux-x64'
-  - job: macos
-    <<: *job_configuration
-    variables:
-      buildConfiguration: 'release'
-      buildPlatform: 'osx-x64'
+  build:
+    windows:
+      <<: *job_configuration
+      variables:
+        buildConfiguration: 'release'
+        buildPlatform: 'win-x64'
+    linux:
+      <<: *job_configuration
+      variables:
+        buildConfiguration: 'release'
+        buildPlatform: 'linux-x64'
+    macos:
+      <<: *job_configuration
+      variables:
+        buildConfiguration: 'release'
+        buildPlatform: 'osx-x64'

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ version: 2
     - run: dotnet build KlSS.csproj --configuration $BUILDCONFIGURATION
     - run: dotnet publish -r $BUILDPLATFORM --configuration $BUILDCONFIGURATION /p:TrimUnusedDependencies=true
     - run: apt-get update && apt-get install -y zip
-    - run: zip -r ~/repo/KlSS.zip ~/repo/bin/release/netcoreapp2.2/$BUILDPLATFORM/publish
+    - run: cd ~/repo/bin/release/netcoreapp2.2/$BUILDPLATFORM/publish && zip -r ~/repo/KlSS.zip ./
     - store_artifacts:
         path: ~/repo/KlSS.zip
 

--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,8 @@ version: 2
   working_directory: ~/repo
   steps:
     - checkout
-    - script: dotnet build KlSS.csproj --configuration $(buildConfiguration)
-    - script: dotnet publish -r $(buildPlatform) --configuration $(buildConfiguration) /p:TrimUnusedDependencies=true
+    - run: dotnet build KlSS.csproj --configuration $(buildConfiguration)
+    - run: dotnet publish -r $(buildPlatform) --configuration $(buildConfiguration) /p:TrimUnusedDependencies=true
     - store_artifacts:
         path: ~/repo/
 
@@ -31,7 +31,7 @@ jobs:
 #    docker:
 #      - image: dosowisko/butler
 #    steps:
-#      - butler --help
+#      - run: butler --help
 
 workflows:
   version: 2


### PR DESCRIPTION
Here's an example:
https://circleci.com/workflow-run/acff89dd-c8f6-42d5-8fc4-c95ef6cf92f3

The builds can be downloaded in artifacts tab of each job. Next step would be to use [itchio/butler](https://github.com/itchio/butler) or the [dosowisko/butler](https://hub.docker.com/r/dosowisko/butler/dockerfile/) docker image maintained by some guy and deploy to itch.io automatically :)

Confirmed working for macos:
https://52-180013919-gh.circle-artifacts.com/0/root/repo/artifacts/KlSS-osx-x64.zip
![image](https://user-images.githubusercontent.com/1264761/55692765-e980f100-5978-11e9-8bf1-f7d70d98a419.png)

:v:

To get this working, you'll first need to create an account at [circleci](https://circleci.com/) (use yout github account) then enable circleci for your project. The readme badge should already point to the right place. Enjoy :)

There is some kind of workaround in here as some command lines downloaded by nuget are not executable when downloaded during the first build attempt. This could be improved, but at least it works

Also note: no need to `chmod +x` the macos artifact binary when built using circleci (compared to when you build using windows on your machine), it works out of the box here.

Most of the job was in fact to get `dotnet` and `mono` together, this was done in here: https://github.com/gableroux/docker-dotnet-mono-monogame